### PR TITLE
Add download button for generated paper

### DIFF
--- a/generate_paper.php
+++ b/generate_paper.php
@@ -105,11 +105,50 @@ foreach ($sections as $title => $questions) {
     $html .= '</ol>';
 }
 
-$mpdf = new \Mpdf\Mpdf();
-if (ob_get_length()) {
-    ob_end_clean();
-}
-$mpdf->WriteHTML($html);
-$mpdf->Output('paper.pdf', 'I');
+ $mpdf = new \Mpdf\Mpdf();
+ $mpdf->WriteHTML($html);
+ 
+ // Save PDF to a file instead of forcing inline display
+ $filename = 'paper_' . time() . '.pdf';
+ $filepath = __DIR__ . '/export/' . $filename;
+ $mpdf->Output($filepath, 'F');
+ 
+ if (ob_get_length()) {
+     ob_end_clean();
+ }
+ 
+ $fileurl = 'export/' . $filename;
+ ?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Generated Paper</title>
+    <style>
+        .download-btn {
+            display: inline-block;
+            padding: 10px 15px;
+            background: #007bff;
+            color: #fff;
+            text-decoration: none;
+            border-radius: 4px;
+            margin: 20px;
+        }
+        iframe {
+            width: 100%;
+            height: 90vh;
+            border: none;
+        }
+    </style>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+</head>
+<body>
+    <div style="text-align:center;">
+        <a href="<?php echo htmlspecialchars($fileurl); ?>" class="download-btn" download>Download PDF</a>
+    </div>
+    <iframe src="<?php echo htmlspecialchars($fileurl); ?>"></iframe>
+</body>
+</html>
+<?php
 exit;
 ?>


### PR DESCRIPTION
## Summary
- Save generated paper PDF to server and present it in an HTML page
- Add a download button and embedded viewer so mobile users can download the paper

## Testing
- `php -l generate_paper.php`


------
https://chatgpt.com/codex/tasks/task_e_68bbbb6209d4832cb39926f3546bd877