### PR TITLE
Handle missing mPDF autoloaders in generate_paper

### DIFF
--- a/generate_paper.php
+++ b/generate_paper.php
@@ -6,7 +6,28 @@ if (!isset($_SESSION['paperloggedin']) || $_SESSION['paperloggedin'] !== true) {
     exit;
 }
 
-require_once __DIR__ . '/lib/mpdf/vendor/autoload.php';
+require_once __DIR__ . '/logger.php';
+
+// Possible autoloader paths in priority order
+$autoloadPaths = [
+    __DIR__ . '/lib/mpdf/vendor/autoload.php',
+    __DIR__ . '/vendor/autoload.php'
+];
+$autoloadLoaded = false;
+foreach ($autoloadPaths as $autoload) {
+    if (file_exists($autoload)) {
+        require_once $autoload;
+        $autoloadLoaded = true;
+        break;
+    }
+}
+if (!$autoloadLoaded) {
+    $message = 'Unable to load required autoloader. Checked paths: lib/mpdf/vendor/autoload.php and vendor/autoload.php';
+    if (isset($logger)) {
+        $logger->error($message);
+    }
+    exit($message);
+}
 
 include 'database.php';
 

--- a/generate_paper.php
+++ b/generate_paper.php
@@ -127,10 +127,34 @@ foreach ($sections as $title => $questions) {
 }
 
 $mpdf = new \Mpdf\Mpdf();
+$mpdf->WriteHTML($html);
+$pdfContent = $mpdf->Output('', 'S');
 if (ob_get_length()) {
     ob_end_clean();
 }
-$mpdf->WriteHTML($html);
-$mpdf->Output('paper.pdf', 'I');
+$base64Pdf = base64_encode($pdfContent);
+$downloadUrl = 'data:application/pdf;base64,' . $base64Pdf;
+$title = htmlspecialchars($paperName, ENT_QUOTES, 'UTF-8');
+$htmlOutput = <<<HTML
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{$title}</title>
+<style>
+    body,html{margin:0;padding:0;height:100%;}
+    iframe{width:100%;height:90vh;border:none;}
+    .download-btn{display:block;width:100%;text-align:center;padding:15px;background:#007bff;color:#fff;text-decoration:none;font-size:18px;}
+</style>
+</head>
+<body>
+<iframe src="$downloadUrl"></iframe>
+<a class="download-btn" href="$downloadUrl" download="paper.pdf">Download PDF</a>
+</body>
+</html>
+HTML;
+
+echo $htmlOutput;
 exit;
 ?>


### PR DESCRIPTION
## Summary
- Add logger bootstrapping and flexible autoloader paths for mPDF
- Log and exit with clear message if no autoloader found

## Testing
- `php -l generate_paper.php`


------
https://chatgpt.com/codex/tasks/task_e_68bbbd131430832c92db57fe8a3fca94