### PR TITLE
Stream generated paper PDFs directly to browser

### DIFF
--- a/generate_paper.php
+++ b/generate_paper.php
@@ -128,33 +128,15 @@ foreach ($sections as $title => $questions) {
 
 $mpdf = new \Mpdf\Mpdf();
 $mpdf->WriteHTML($html);
-$pdfContent = $mpdf->Output('', 'S');
+
+// Clean any existing output buffers to prevent corrupting the PDF
 if (ob_get_length()) {
     ob_end_clean();
 }
-$base64Pdf = base64_encode($pdfContent);
-$downloadUrl = 'data:application/pdf;base64,' . $base64Pdf;
-$title = htmlspecialchars($paperName, ENT_QUOTES, 'UTF-8');
-$htmlOutput = <<<HTML
-<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<title>{$title}</title>
-<style>
-    body,html{margin:0;padding:0;height:100%;}
-    iframe{width:100%;height:90vh;border:none;}
-    .download-btn{display:block;width:100%;text-align:center;padding:15px;background:#007bff;color:#fff;text-decoration:none;font-size:18px;}
-</style>
-</head>
-<body>
-<iframe src="$downloadUrl"></iframe>
-<a class="download-btn" href="$downloadUrl" download="paper.pdf">Download PDF</a>
-</body>
-</html>
-HTML;
 
-echo $htmlOutput;
+// Stream the PDF directly to the browser so it can be viewed inline
+header('Content-Type: application/pdf');
+header('Content-Disposition: inline; filename="paper.pdf"');
+$mpdf->Output('paper.pdf', \Mpdf\Output\Destination::INLINE);
 exit;
 ?>


### PR DESCRIPTION
## Summary
- Serve generated question paper PDF via standard HTTP response instead of embedding as base64 to improve mobile compatibility.

## Testing
- `php -l generate_paper.php`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bbc02e9fec832c8e1cb301217c5cd1