### PR TITLE
Add super admin role and permission management

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -1,0 +1,36 @@
+<?php
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+function is_super_admin(): bool {
+    return isset($_SESSION['role']) && $_SESSION['role'] === 'super_admin';
+}
+
+function require_super_admin(): void {
+    if (!is_super_admin()) {
+        header('HTTP/1.1 403 Forbidden');
+        echo 'Access denied';
+        exit;
+    }
+}
+
+function require_permission(string $page): void {
+    if (is_super_admin()) {
+        return; // super admin has full access
+    }
+    $permissionsFile = __DIR__ . '/permissions.json';
+    $permissions = [];
+    if (file_exists($permissionsFile)) {
+        $json = file_get_contents($permissionsFile);
+        $permissions = json_decode($json, true) ?: [];
+    }
+    $email = $_SESSION['email'] ?? '';
+    $allowed = $permissions[$email] ?? [];
+    if (!in_array('*', $allowed, true) && !in_array($page, $allowed, true)) {
+        header('HTTP/1.1 403 Forbidden');
+        echo 'Access denied';
+        exit;
+    }
+}
+?>

--- a/includes/sidebar.php
+++ b/includes/sidebar.php
@@ -1,4 +1,5 @@
 <?php
+include_once __DIR__ . '/../auth.php';
 $logout = isset($_SESSION['studentloggedin']) ? 'studentlogout.php' : 'instructorlogout.php';
 
 // Determine where the "Take Quiz" link should point for students
@@ -55,6 +56,9 @@ if (isset($_SESSION['studentloggedin']) && $_SESSION['studentloggedin'] === true
             <li><a href="manage_instructors.php"><i class="fas fa-user-tie"></i><span>Manage Instructors</span></a></li>
             <li><a href="manage_students.php"><i class="fas fa-user-graduate"></i><span>Manage Students</span></a></li>
             <li><a href="manage_notifications.php"><i class="fas fa-bell"></i><span>Manage Notifications</span></a></li>
+            <?php if (is_super_admin()): ?>
+            <li><a href="manage_permissions.php"><i class="fas fa-lock"></i><span>Manage Access</span></a></li>
+            <?php endif; ?>
             <li><a href="paper_home.php"><i class="fas fa-file-alt"></i><span>Generate Paper</span></a></li>
             <li><a href="paper_manage.php"><i class="fas fa-users-cog"></i><span>Manage Paper Generator App</span></a></li>
             <li><a href="my_profile.php"><i class="fas fa-user"></i><span>My Profile</span></a></li>

--- a/instructorhome.php
+++ b/instructorhome.php
@@ -1,9 +1,11 @@
 <?php
   session_start();
+  require_once 'auth.php';
   if(!isset($_SESSION["instructorloggedin"]) || $_SESSION["instructorloggedin"] !== true){
       header("location: instructorlogin.php");
       exit;
   }
+  require_permission(basename(__FILE__));
 ?>
 <!DOCTYPE html>
 <html lang="en">

--- a/instructorlogin.php
+++ b/instructorlogin.php
@@ -42,6 +42,12 @@
 
                     $_SESSION["instructorloggedin"] = true;
                     $_SESSION["email"] = $email;
+                    // Determine role based on email
+                    if ($email === 'superadmin@example.com') {
+                        $_SESSION['role'] = 'super_admin';
+                    } else {
+                        $_SESSION['role'] = 'instructor';
+                    }
                     header("Location: instructorhome.php");
                     exit; // Crucial
                 }

--- a/manage_instructors.php
+++ b/manage_instructors.php
@@ -1,10 +1,12 @@
 <?php
 session_start();
+require_once 'auth.php';
 // Ensure instructor is logged in
 if (!isset($_SESSION["instructorloggedin"]) || $_SESSION["instructorloggedin"] !== true) {
     header("location: instructorlogin.php");
     exit;
 }
+require_permission(basename(__FILE__));
 
 include "database.php"; // Database connection
 

--- a/manage_permissions.php
+++ b/manage_permissions.php
@@ -1,0 +1,52 @@
+<?php
+require_once 'auth.php';
+require_super_admin();
+
+$permissionsFile = __DIR__ . '/permissions.json';
+$permissions = [];
+if (file_exists($permissionsFile)) {
+    $permissions = json_decode(file_get_contents($permissionsFile), true) ?: [];
+}
+$message = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $email = trim($_POST['email'] ?? '');
+    $pagesRaw = trim($_POST['pages'] ?? '');
+    if ($email !== '') {
+        $pages = array_filter(array_map('trim', explode(',', $pagesRaw)));
+        $permissions[$email] = $pages;
+        file_put_contents($permissionsFile, json_encode($permissions, JSON_PRETTY_PRINT));
+        $message = 'Permissions updated for ' . htmlspecialchars($email);
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Manage Permissions</title>
+    <link rel="stylesheet" href="./assets/css/material-kit.css?v=2.0.4" />
+    <link rel="stylesheet" href="./assets/css/modern.css" />
+</head>
+<body>
+<div class="container" style="margin-top:40px;">
+    <h2>Manage User Permissions</h2>
+    <?php if($message): ?>
+        <div class="alert alert-success"><?php echo $message; ?></div>
+    <?php endif; ?>
+    <form method="post">
+        <div class="form-group">
+            <label>Email</label>
+            <input type="email" name="email" class="form-control" required>
+        </div>
+        <div class="form-group">
+            <label>Allowed Pages (comma separated, use * for all)</label>
+            <input type="text" name="pages" class="form-control" required>
+        </div>
+        <button type="submit" class="btn btn-primary">Save</button>
+    </form>
+    <h3 class="mt-5">Current Permissions</h3>
+    <pre><?php echo htmlspecialchars(json_encode($permissions, JSON_PRETTY_PRINT)); ?></pre>
+</div>
+</body>
+</html>

--- a/manage_students.php
+++ b/manage_students.php
@@ -1,10 +1,12 @@
 <?php
 session_start();
+require_once 'auth.php';
 // Ensure instructor is logged in
 if (!isset($_SESSION["instructorloggedin"]) || $_SESSION["instructorloggedin"] !== true) {
     header("location: instructorlogin.php");
     exit;
 }
+require_permission(basename(__FILE__));
 
 include "database.php"; // Database connection
 

--- a/permissions.json
+++ b/permissions.json
@@ -1,0 +1,3 @@
+{
+  "superadmin@example.com": ["*"]
+}


### PR DESCRIPTION
## Summary
- Add session-based super admin role with permission checks
- Provide JSON-backed permissions and UI to manage access
- Protect instructor pages using new permission middleware and sidebar link

## Testing
- `php -l auth.php`
- `php -l manage_permissions.php`
- `php -l instructorlogin.php`
- `php -l instructorhome.php`
- `php -l manage_students.php`
- `php -l manage_instructors.php`
- `php -l includes/sidebar.php`


------
https://chatgpt.com/codex/tasks/task_e_68bbd57dff90832ca989cc86464fbaac