### PR TITLE
Use paper name for generated PDF filename

### DIFF
--- a/generate_paper.php
+++ b/generate_paper.php
@@ -14,9 +14,18 @@ if (isset($_GET['pdf'])) {
         exit('PDF not found');
     }
 
+    // Build a safe filename based on the stored paper name
+    $fileName = $_SESSION['generated_pdf_name'] ?? 'paper';
+    $fileName = preg_replace('/[^A-Za-z0-9 _-]/', '_', $fileName);
+    $fileName = trim($fileName);
+    if ($fileName === '') {
+        $fileName = 'paper';
+    }
+    $fileName .= '.pdf';
+
     header('Content-Type: application/pdf');
     $disposition = isset($_GET['download']) ? 'attachment' : 'inline';
-    header('Content-Disposition: ' . $disposition . '; filename="paper.pdf"');
+    header('Content-Disposition: ' . $disposition . '; filename="' . $fileName . '"');
     echo $pdfContent;
     exit;
 }
@@ -152,6 +161,7 @@ $mpdf->WriteHTML($html);
 // Store PDF content in session for later download/view
 $pdfContent = $mpdf->Output('', \Mpdf\Output\Destination::STRING_RETURN);
 $_SESSION['generated_pdf'] = $pdfContent;
+$_SESSION['generated_pdf_name'] = $paperName;
 
 // Clean any existing output buffers to prevent corrupting the output
 if (ob_get_length()) {


### PR DESCRIPTION
## Summary
- Derive a safe PDF filename from the paper name and return PDFs with that name.
- Persist the paper name in session when generating a PDF so download links use it.

## Testing
- `php -l generate_paper.php`


------
https://chatgpt.com/codex/tasks/task_e_68bbd6ef0dcc832c9d63b00a11800ae7