### PR TITLE
Serve generated paper as static file

### DIFF
--- a/generate_paper.php
+++ b/generate_paper.php
@@ -222,12 +222,12 @@ $tokenDir = $baseExport . '/' . $token;
 if (!is_dir($tokenDir)) {
     mkdir($tokenDir, 0777, true);
 }
-$relativePath = 'export/' . $token . '/' . $pdfFileName;
 $absolutePath = $tokenDir . '/' . $pdfFileName;
 $mpdf->Output($absolutePath, \Mpdf\Output\Destination::FILE);
+$relativeUrl = 'export/' . $token . '/' . rawurlencode($pdfFileName);
 $_SESSION['generated_pdf'] = [
     'path' => $absolutePath,
-    'url'  => $relativePath,
+    'url'  => '/' . $relativeUrl,
     'token' => $token,
     'uses'  => 2,
     'filename' => $pdfFileName


### PR DESCRIPTION
## Summary
- Redirect generated papers to static files instead of streaming through PHP
- Store PDFs in export directory with unique token-based paths

## Testing
- `php -l generate_paper.php`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bbf5908ccc832cb22d2199cb6b26c7