### PR TITLE
Center paper header and align logo to left

### DIFF
--- a/generate_paper.php
+++ b/generate_paper.php
@@ -165,12 +165,20 @@ if ($conn) {
     $conn->close();
 }
 
-$html = '<div style="text-align:center;">';
-if ($logo) $html .= '<img src="'.htmlspecialchars($logo).'" height="80"><br>';
-$html .= '<h2>'.htmlspecialchars($header).'</h2>';
-$html .= '<h3>'.htmlspecialchars($paperName).'</h3>';
-if ($paperDate) $html .= '<div>Date: '.htmlspecialchars($paperDate).'</div>';
-$html .= '</div>';
+$html = '<table style="width:100%;border:0;margin-bottom:10px;">';
+$html .= '<tr>';
+if ($logo) {
+    $html .= '<td style="width:20%;text-align:left;"><img src="'.htmlspecialchars($logo).'" height="80"></td>';
+} else {
+    $html .= '<td style="width:20%;"></td>';
+}
+$html .= '<td style="text-align:center;">';
+$html .= '<h2 style="margin:0;">'.htmlspecialchars($header).'</h2>';
+$html .= '<h3 style="margin:0;">'.htmlspecialchars($paperName).'</h3>';
+if ($paperDate) $html .= '<div style="margin-top:4px;">Date: '.htmlspecialchars($paperDate).'</div>';
+$html .= '</td>';
+$html .= '</tr>';
+$html .= '</table>';
 
 foreach ($sections as $title => $questions) {
     if (count($questions) === 0) continue;

--- a/generate_paper.php
+++ b/generate_paper.php
@@ -168,15 +168,16 @@ if ($conn) {
 $html = '<table style="width:100%;border:0;margin-bottom:10px;">';
 $html .= '<tr>';
 if ($logo) {
-    $html .= '<td style="width:20%;text-align:left;"><img src="'.htmlspecialchars($logo).'" height="80"></td>';
+    $html .= '<td style="width:20%;text-align:left;"><img src="'.htmlspecialchars($logo).'" height="60"></td>';
 } else {
     $html .= '<td style="width:20%;"></td>';
 }
-$html .= '<td style="text-align:center;">';
-$html .= '<h2 style="margin:0;">'.htmlspecialchars($header).'</h2>';
-$html .= '<h3 style="margin:0;">'.htmlspecialchars($paperName).'</h3>';
-if ($paperDate) $html .= '<div style="margin-top:4px;">Date: '.htmlspecialchars($paperDate).'</div>';
+$html .= '<td style="width:60%;text-align:center;">';
+$html .= '<div style="margin:0;font-size:20px;font-weight:bold;">'.htmlspecialchars($header).'</div>';
+$html .= '<div style="margin:0;font-size:16px;">'.htmlspecialchars($paperName).'</div>';
+if ($paperDate) $html .= '<div style="margin-top:4px;font-size:14px;">Date: '.htmlspecialchars($paperDate).'</div>';
 $html .= '</td>';
+$html .= '<td style="width:20%;"></td>';
 $html .= '</tr>';
 $html .= '</table>';
 

--- a/generate_paper.php
+++ b/generate_paper.php
@@ -165,10 +165,10 @@ if ($conn) {
     $conn->close();
 }
 
-$html = '<table style="width:100%;border:0;margin-bottom:10px;">';
+$html = '<table style="width:100%;border:0;margin-bottom:5px;">';
 $html .= '<tr>';
 if ($logo) {
-    $html .= '<td style="width:20%;text-align:left;"><img src="'.htmlspecialchars($logo).'" height="60"></td>';
+    $html .= '<td style="width:20%;text-align:left;"><img src="'.htmlspecialchars($logo).'" height="50"></td>';
 } else {
     $html .= '<td style="width:20%;"></td>';
 }
@@ -198,7 +198,7 @@ foreach ($sections as $title => $questions) {
     $html .= '</ol>';
 }
 
-$mpdf = new \Mpdf\Mpdf();
+$mpdf = new \Mpdf\Mpdf(['margin_top' => 5]);
 $mpdf->WriteHTML($html);
 
 // Remove previously generated PDF if it exists


### PR DESCRIPTION
## Summary
- Arrange the generated paper header with a left-aligned logo and centered header text to save vertical space.

## Testing
- `php -l generate_paper.php`


------
https://chatgpt.com/codex/tasks/task_e_68bcda04cc60832c921bb7fab6d7fef0