### PR TITLE
Use utf8mb4 for question tables

### DIFF
--- a/Extra files/create_random_questions_table.php
+++ b/Extra files/create_random_questions_table.php
@@ -9,7 +9,7 @@ $sql = "CREATE TABLE IF NOT EXISTS random_quiz_questions (
   serialnumber int(11) NOT NULL,
   PRIMARY KEY (quizid, qtype, qid),
   FOREIGN KEY (quizid) REFERENCES quizconfig(quizid) ON DELETE CASCADE ON UPDATE CASCADE
-)";
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci";
 
 if ($conn->query($sql) === TRUE) {
     echo "Table random_quiz_questions created successfully";

--- a/Extra files/debug_quiz_issue.php
+++ b/Extra files/debug_quiz_issue.php
@@ -22,14 +22,14 @@ echo "<ul>";
 echo "<li>random_quiz_questions table exists: " . ($table_result->num_rows > 0 ? "Yes" : "No") . "</li>";
 
 // If the table doesn't exist, attempt to create it
-if ($table_result->num_rows == 0) {
-    $create_sql = "CREATE TABLE IF NOT EXISTS random_quiz_questions (
-      quizid int(11) NOT NULL,
-      qtype varchar(20) NOT NULL,
-      qid int(11) NOT NULL,
-      serialnumber int(11) NOT NULL,
-      PRIMARY KEY (quizid, qtype, qid)
-    )";
+    if ($table_result->num_rows == 0) {
+        $create_sql = "CREATE TABLE IF NOT EXISTS random_quiz_questions (
+          quizid int(11) NOT NULL,
+          qtype varchar(20) NOT NULL,
+          qid int(11) NOT NULL,
+          serialnumber int(11) NOT NULL,
+          PRIMARY KEY (quizid, qtype, qid)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci";
     
     if ($conn->query($create_sql)) {
         echo "<li style='color: green;'>Successfully created random_quiz_questions table!</li>";

--- a/Extra files/handle_quiz_patch.php
+++ b/Extra files/handle_quiz_patch.php
@@ -49,7 +49,7 @@ if (!tableExists($conn, 'random_quiz_questions')) {
         qid int(11) NOT NULL,
         serialnumber int(11) NOT NULL,
         PRIMARY KEY (quizid, qtype, qid)
-    )";
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci";
     
     if ($conn->query($create_table_sql)) {
         echo "<div style='color:green;'>Successfully created random_quiz_questions table!</div>";

--- a/create_random_questions.sql
+++ b/create_random_questions.sql
@@ -6,4 +6,4 @@ CREATE TABLE IF NOT EXISTS random_quiz_questions (
   serialnumber int(11) NOT NULL,
   PRIMARY KEY (quizid, qtype, qid),
   CONSTRAINT fk_random_quiz_quizid FOREIGN KEY (quizid) REFERENCES quizconfig(quizid) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4; 
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/install_random_questions_table.php
+++ b/install_random_questions_table.php
@@ -18,7 +18,7 @@ $sql = "CREATE TABLE IF NOT EXISTS random_quiz_questions (
   qid int(11) NOT NULL,
   serialnumber int(11) NOT NULL,
   PRIMARY KEY (quizid, qtype, qid)
-)";
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci";
 
 echo "<h2>Creating random_quiz_questions table</h2>";
 echo "SQL: " . htmlspecialchars($sql) . "<br><br>";

--- a/sql/Database.sql
+++ b/sql/Database.sql
@@ -151,7 +151,7 @@ CREATE TABLE `dropdown` (
   `answer` varchar(255) NOT NULL,
   `chapter_id` int(11) DEFAULT NULL,
   `topic_id` int(11) DEFAULT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- --------------------------------------------------------
 
@@ -165,7 +165,7 @@ CREATE TABLE `essay` (
   `answer` text NOT NULL,
   `chapter_id` int(11) DEFAULT NULL,
   `topic_id` int(11) DEFAULT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 --
 -- Dumping data for table `essay`
@@ -235,7 +235,7 @@ CREATE TABLE `fillintheblanks` (
   `answer` varchar(255) NOT NULL,
   `chapter_id` int(11) DEFAULT NULL,
   `topic_id` int(11) DEFAULT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 --
 -- Dumping data for table `fillintheblanks`
@@ -1209,7 +1209,7 @@ CREATE TABLE `mcqdb` (
   `answer` char(1) NOT NULL,
   `chapter_id` int(11) DEFAULT NULL,
   `topic_id` int(11) DEFAULT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 --
 -- Dumping data for table `mcqdb`
@@ -3392,7 +3392,7 @@ CREATE TABLE `numericaldb` (
   `answer` int(11) NOT NULL,
   `chapter_id` int(11) DEFAULT NULL,
   `topic_id` int(11) DEFAULT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- --------------------------------------------------------
 
@@ -3621,7 +3621,7 @@ CREATE TABLE `random_quiz_questions` (
   `qtype` varchar(20) NOT NULL,
   `qid` int(11) NOT NULL,
   `serialnumber` int(11) NOT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 --
 -- Dumping data for table `random_quiz_questions`
@@ -3854,7 +3854,7 @@ CREATE TABLE `response` (
   `qid` int(11) NOT NULL,
   `response` text NOT NULL,
   `serialnumber` int(11) NOT NULL DEFAULT 1
-) ENGINE=InnoDB DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 --
 -- Dumping data for table `response`
@@ -6377,7 +6377,7 @@ CREATE TABLE `shortanswer` (
   `answer` text NOT NULL,
   `chapter_id` int(11) DEFAULT NULL,
   `topic_id` int(11) DEFAULT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 --
 -- Dumping data for table `shortanswer`


### PR DESCRIPTION
## Summary
- migrate question-related tables to utf8mb4 charset to safely store math symbols
- align helper scripts so random question table creation uses utf8mb4

## Testing
- `composer test` *(fails: Command "test" is not defined)*
- `npm test` *(fails: no test specified)*
- `php -l install_random_questions_table.php "Extra files/create_random_questions_table.php" "Extra files/handle_quiz_patch.php" "Extra files/debug_quiz_issue.php"`

------
https://chatgpt.com/codex/tasks/task_e_68bee2e6adac832cb9d8d0cbceec34ed