### PR TITLE
Prevent incomplete or duplicate questions in quizzes

### DIFF
--- a/get_questions.php
+++ b/get_questions.php
@@ -62,6 +62,13 @@ if (!isset($table_map[$type])) {
 
 $table_info = $table_map[$type];
 $sql = "SELECT id, question FROM {$table_info['table']} WHERE chapter_id IN ($chapter_ids_str)$topic_filter";
+// Ensure MCQ questions have all options present
+if ($type === 'mcq') {
+    $sql .= " AND optiona IS NOT NULL AND optiona <> ''"
+          . " AND optionb IS NOT NULL AND optionb <> ''"
+          . " AND optionc IS NOT NULL AND optionc <> ''"
+          . " AND optiond IS NOT NULL AND optiond <> ''";
+}
 $logger->debug('SQL Query', $sql);
 
 try {


### PR DESCRIPTION
## Summary
- filter MCQ questions lacking options from question feed
- skip incomplete MCQs and avoid reusing questions when generating random quizzes
- replace visible debug output on quiz page with internal logging

## Testing
- `php -l get_questions.php`
- `php -l randomqgen.php`
- `php -l quizpage.php`


------
https://chatgpt.com/codex/tasks/task_e_68c4c3426398832c8cb6d2514f23790b